### PR TITLE
fix: label node alignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gtk-grafana/react-json-tree",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "React JSON Viewer Component, Extracted from redux-devtools",
   "keywords": [
     "react",

--- a/src/styles/JSONNestedNode.module.scss
+++ b/src/styles/JSONNestedNode.module.scss
@@ -21,7 +21,7 @@
 }
 
 .nestedNodeLabelWrap {
-  display: var(--json-tree-inline-flex);
+  display: var(--json-tree-block);
   align-items: var(--json-tree-align-items);
   cursor: pointer;
 }


### PR DESCRIPTION
Expand arrow was not aligned for the root node due to inline-flex style. Changing to flex.