### PR TITLE
chore: bump vite version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gtk-grafana/react-json-tree",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "React JSON Viewer Component, Extracted from redux-devtools",
   "keywords": [
     "react",
@@ -103,7 +103,7 @@
     "terser": "^5.39.0",
     "typescript": "5.7.3",
     "typescript-eslint": "8.25.0",
-    "vite": "6.2.0",
+    "vite": "6.2.3",
     "vite-plugin-css-injected-by-js": "^3.5.2",
     "vite-plugin-dts": "4.5.1",
     "vite-plugin-externals": "^0.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5382,7 +5382,18 @@ vite-plugin-lib-inject-css@2.2.1:
     magic-string "^0.30.17"
     picocolors "^1.1.1"
 
-vite@6.2.0, "vite@^5.0.0 || ^6.0.0":
+vite@6.2.3:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-6.2.3.tgz#249e92d32886981ab46bc1f049ac72abc6fa81e2"
+  integrity sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==
+  dependencies:
+    esbuild "^0.25.0"
+    postcss "^8.5.3"
+    rollup "^4.30.1"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+"vite@^5.0.0 || ^6.0.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/vite/-/vite-6.2.0.tgz#9dcb543380dab18d8384eb840a76bf30d78633f0"
   integrity sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ==


### PR DESCRIPTION
Vulnerability on 6.2.0, upgrading to patched 6.2.3