### PR TITLE
feat: add hideRootExpand

### DIFF
--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -82,124 +82,124 @@ const data: Record<string, any> = {
 const key: KeyPath = [];
 
 const App = () => (
-    <div style={{background: "#fff"}}>
-        <h3>Basic Example</h3>
-        <div style={{background: "#222"}}>
-            <JSONTree data={data}/>
-        </div>
-        <br/>
+  <div style={{ background: "#fff" }}>
+    <h3>Basic Example</h3>
+    <div style={{ background: "#222" }}>
+      <JSONTree data={data} />
+    </div>
+    <br />
 
-        <h3>Hide root node</h3>
-        <div style={{background: "#222"}}>
-            <JSONTree hideRoot={true} data={data}/>
-        </div>
-        <br/>
+    <h3>Hide root node</h3>
+    <div style={{ background: "#222" }}>
+      <JSONTree hideRoot={true} data={data} />
+    </div>
+    <br />
 
-        <h3>Force root node open</h3>
-        <div style={{background: "#222"}}>
-            <JSONTree hideRootExpand={true} data={data}/>
-        </div>
-        <br/>
+    <h3>Force root node open</h3>
+    <div style={{ background: "#222" }}>
+      <JSONTree hideRootExpand={true} data={data} />
+    </div>
+    <br />
 
-        <h3>Theming Example</h3>
-        <p>
-            Styles are managed with css variables, override the default values to
-            customize.
-        </p>
-        <div
-            style={
-                {
-                    "--json-tree-label-color": "rgb(12, 127, 149)",
-                    "--json-tree-key-label-color": "rgb(71, 131, 0)",
-                    "--json-tree-label-value-color": "rgb(255, 48, 124)",
-                    "--json-tree-arrow-color": "rgb(12, 127, 149)",
-                    "--json-tree-value-text-wrap": "nowrap",
-                } as React.CSSProperties
-            }
-        >
-            <JSONTree data={data}/>
-        </div>
+    <h3>Theming Example</h3>
+    <p>
+      Styles are managed with css variables, override the default values to
+      customize.
+    </p>
+    <div
+      style={
+        {
+          "--json-tree-label-color": "rgb(12, 127, 149)",
+          "--json-tree-key-label-color": "rgb(71, 131, 0)",
+          "--json-tree-label-value-color": "rgb(255, 48, 124)",
+          "--json-tree-arrow-color": "rgb(12, 127, 149)",
+          "--json-tree-value-text-wrap": "nowrap",
+        } as React.CSSProperties
+      }
+    >
+      <JSONTree data={data} />
+    </div>
 
-        <h3>Theming Example - relative position arrows</h3>
-        <p>
-            Styles are managed with css variables, override the default values to
-            customize.
-        </p>
-        <div
-            style={
-                {
-                    "--json-tree-label-color": "rgb(12, 127, 149)",
-                    "--json-tree-key-label-color": "rgb(71, 131, 0)",
-                    "--json-tree-label-value-color": "rgb(255, 48, 124)",
-                    "--json-tree-arrow-color": "rgb(12, 127, 149)",
-                    "--json-tree-arrow-position": "relative",
-                    "--json-tree-ul-root-padding": "0",
-                    "--json-tree-arrow-left-offset": "0",
-                    "--json-tree-arrow-right-margin": "0.5em",
-                } as React.CSSProperties
-            }
-        >
-            <JSONTree data={data}/>
-        </div>
+    <h3>Theming Example - relative position arrows</h3>
+    <p>
+      Styles are managed with css variables, override the default values to
+      customize.
+    </p>
+    <div
+      style={
+        {
+          "--json-tree-label-color": "rgb(12, 127, 149)",
+          "--json-tree-key-label-color": "rgb(71, 131, 0)",
+          "--json-tree-label-value-color": "rgb(255, 48, 124)",
+          "--json-tree-arrow-color": "rgb(12, 127, 149)",
+          "--json-tree-arrow-position": "relative",
+          "--json-tree-ul-root-padding": "0",
+          "--json-tree-arrow-left-offset": "0",
+          "--json-tree-arrow-right-margin": "0.5em",
+        } as React.CSSProperties
+      }
+    >
+      <JSONTree data={data} />
+    </div>
 
-        <h3>Style Customization</h3>
-        <ul>
-            <li>
-                Label changes between uppercase/lowercase based on the expanded state.
-            </li>
-            <li>Array keys are styled based on their parity.</li>
-            <li>
-                The labels of objects, arrays, and iterables are customized as &quot;//
-                type&quot;.
-            </li>
-            <li>See code for details.</li>
-        </ul>
-        <div>
-            <JSONTree data={data} getItemString={getItemString}/>
-        </div>
-        <h3>More Fine Grained Rendering</h3>
-        <p>
-            Pass <code>labelRenderer</code> or <code>valueRenderer</code>.
-        </p>
-        <div>
-            <JSONTree
-                data={data}
-                labelRenderer={([raw]) => <span>(({raw})):</span>}
-                valueRenderer={(raw) => (
-                    <em>
+    <h3>Style Customization</h3>
+    <ul>
+      <li>
+        Label changes between uppercase/lowercase based on the expanded state.
+      </li>
+      <li>Array keys are styled based on their parity.</li>
+      <li>
+        The labels of objects, arrays, and iterables are customized as &quot;//
+        type&quot;.
+      </li>
+      <li>See code for details.</li>
+    </ul>
+    <div>
+      <JSONTree data={data} getItemString={getItemString} />
+    </div>
+    <h3>More Fine Grained Rendering</h3>
+    <p>
+      Pass <code>labelRenderer</code> or <code>valueRenderer</code>.
+    </p>
+    <div>
+      <JSONTree
+        data={data}
+        labelRenderer={([raw]) => <span>(({raw})):</span>}
+        valueRenderer={(raw) => (
+          <em>
             <span role="img" aria-label="mellow">
               😐
             </span>{" "}
-                        {raw as string}{" "}
-                        <span role="img" aria-label="mellow">
+            {raw as string}{" "}
+            <span role="img" aria-label="mellow">
               😐
             </span>
-                    </em>
-                )}
-            />
-        </div>
-        <p>
-            Sort object keys with <code>sortObjectKeys</code> prop.
-        </p>
-        <div>
-            <JSONTree data={data} sortObjectKeys/>
-        </div>
-        <p>Collapsed root node</p>
-        <div>
-            <JSONTree data={data} shouldExpandNodeInitially={() => false}/>
-        </div>
-
-        <p>Collapsed top-level nodes</p>
-        <div>
-            <JSONTree
-                collectionLimit={100}
-                data={Array.from({length: 10000}).map((_, i) => ({
-                    name: `item #${i}`,
-                    value: i,
-                }))}
-            />
-        </div>
+          </em>
+        )}
+      />
     </div>
+    <p>
+      Sort object keys with <code>sortObjectKeys</code> prop.
+    </p>
+    <div>
+      <JSONTree data={data} sortObjectKeys />
+    </div>
+    <p>Collapsed root node</p>
+    <div>
+      <JSONTree data={data} shouldExpandNodeInitially={() => false} />
+    </div>
+
+    <p>Collapsed top-level nodes</p>
+    <div>
+      <JSONTree
+        collectionLimit={100}
+        data={Array.from({ length: 10000 }).map((_, i) => ({
+          name: `item #${i}`,
+          value: i,
+        }))}
+      />
+    </div>
+  </div>
 );
 
 export default App;

--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -82,117 +82,124 @@ const data: Record<string, any> = {
 const key: KeyPath = [];
 
 const App = () => (
-  <div style={{ background: "#fff" }}>
-    <h3>Basic Example</h3>
-    <div style={{ background: "#222" }}>
-      <JSONTree data={data} />
-    </div>
-    <br />
+    <div style={{background: "#fff"}}>
+        <h3>Basic Example</h3>
+        <div style={{background: "#222"}}>
+            <JSONTree data={data}/>
+        </div>
+        <br/>
 
-    <h3>Hide root node</h3>
-    <div style={{ background: "#222" }}>
-      <JSONTree hideRoot={true} data={data} />
-    </div>
-    <br />
-    <h3>Theming Example</h3>
-    <p>
-      Styles are managed with css variables, override the default values to
-      customize.
-    </p>
-    <div
-      style={
-        {
-          "--json-tree-label-color": "rgb(12, 127, 149)",
-          "--json-tree-key-label-color": "rgb(71, 131, 0)",
-          "--json-tree-label-value-color": "rgb(255, 48, 124)",
-          "--json-tree-arrow-color": "rgb(12, 127, 149)",
-          "--json-tree-value-text-wrap": "nowrap",
-        } as React.CSSProperties
-      }
-    >
-      <JSONTree data={data} />
-    </div>
+        <h3>Hide root node</h3>
+        <div style={{background: "#222"}}>
+            <JSONTree hideRoot={true} data={data}/>
+        </div>
+        <br/>
 
-    <h3>Theming Example - relative position arrows</h3>
-    <p>
-      Styles are managed with css variables, override the default values to
-      customize.
-    </p>
-    <div
-      style={
-        {
-          "--json-tree-label-color": "rgb(12, 127, 149)",
-          "--json-tree-key-label-color": "rgb(71, 131, 0)",
-          "--json-tree-label-value-color": "rgb(255, 48, 124)",
-          "--json-tree-arrow-color": "rgb(12, 127, 149)",
-          "--json-tree-arrow-position": "relative",
-          "--json-tree-ul-root-padding": "0",
-          "--json-tree-arrow-left-offset": "0",
-          "--json-tree-arrow-right-margin": "0.5em",
-        } as React.CSSProperties
-      }
-    >
-      <JSONTree data={data} />
-    </div>
+        <h3>Force root node open</h3>
+        <div style={{background: "#222"}}>
+            <JSONTree hideRootExpand={true} data={data}/>
+        </div>
+        <br/>
 
-    <h3>Style Customization</h3>
-    <ul>
-      <li>
-        Label changes between uppercase/lowercase based on the expanded state.
-      </li>
-      <li>Array keys are styled based on their parity.</li>
-      <li>
-        The labels of objects, arrays, and iterables are customized as &quot;//
-        type&quot;.
-      </li>
-      <li>See code for details.</li>
-    </ul>
-    <div>
-      <JSONTree data={data} getItemString={getItemString} />
-    </div>
-    <h3>More Fine Grained Rendering</h3>
-    <p>
-      Pass <code>labelRenderer</code> or <code>valueRenderer</code>.
-    </p>
-    <div>
-      <JSONTree
-        data={data}
-        labelRenderer={([raw]) => <span>(({raw})):</span>}
-        valueRenderer={(raw) => (
-          <em>
+        <h3>Theming Example</h3>
+        <p>
+            Styles are managed with css variables, override the default values to
+            customize.
+        </p>
+        <div
+            style={
+                {
+                    "--json-tree-label-color": "rgb(12, 127, 149)",
+                    "--json-tree-key-label-color": "rgb(71, 131, 0)",
+                    "--json-tree-label-value-color": "rgb(255, 48, 124)",
+                    "--json-tree-arrow-color": "rgb(12, 127, 149)",
+                    "--json-tree-value-text-wrap": "nowrap",
+                } as React.CSSProperties
+            }
+        >
+            <JSONTree data={data}/>
+        </div>
+
+        <h3>Theming Example - relative position arrows</h3>
+        <p>
+            Styles are managed with css variables, override the default values to
+            customize.
+        </p>
+        <div
+            style={
+                {
+                    "--json-tree-label-color": "rgb(12, 127, 149)",
+                    "--json-tree-key-label-color": "rgb(71, 131, 0)",
+                    "--json-tree-label-value-color": "rgb(255, 48, 124)",
+                    "--json-tree-arrow-color": "rgb(12, 127, 149)",
+                    "--json-tree-arrow-position": "relative",
+                    "--json-tree-ul-root-padding": "0",
+                    "--json-tree-arrow-left-offset": "0",
+                    "--json-tree-arrow-right-margin": "0.5em",
+                } as React.CSSProperties
+            }
+        >
+            <JSONTree data={data}/>
+        </div>
+
+        <h3>Style Customization</h3>
+        <ul>
+            <li>
+                Label changes between uppercase/lowercase based on the expanded state.
+            </li>
+            <li>Array keys are styled based on their parity.</li>
+            <li>
+                The labels of objects, arrays, and iterables are customized as &quot;//
+                type&quot;.
+            </li>
+            <li>See code for details.</li>
+        </ul>
+        <div>
+            <JSONTree data={data} getItemString={getItemString}/>
+        </div>
+        <h3>More Fine Grained Rendering</h3>
+        <p>
+            Pass <code>labelRenderer</code> or <code>valueRenderer</code>.
+        </p>
+        <div>
+            <JSONTree
+                data={data}
+                labelRenderer={([raw]) => <span>(({raw})):</span>}
+                valueRenderer={(raw) => (
+                    <em>
             <span role="img" aria-label="mellow">
               😐
             </span>{" "}
-            {raw as string}{" "}
-            <span role="img" aria-label="mellow">
+                        {raw as string}{" "}
+                        <span role="img" aria-label="mellow">
               😐
             </span>
-          </em>
-        )}
-      />
-    </div>
-    <p>
-      Sort object keys with <code>sortObjectKeys</code> prop.
-    </p>
-    <div>
-      <JSONTree data={data} sortObjectKeys />
-    </div>
-    <p>Collapsed root node</p>
-    <div>
-      <JSONTree data={data} shouldExpandNodeInitially={() => false} />
-    </div>
+                    </em>
+                )}
+            />
+        </div>
+        <p>
+            Sort object keys with <code>sortObjectKeys</code> prop.
+        </p>
+        <div>
+            <JSONTree data={data} sortObjectKeys/>
+        </div>
+        <p>Collapsed root node</p>
+        <div>
+            <JSONTree data={data} shouldExpandNodeInitially={() => false}/>
+        </div>
 
-    <p>Collapsed top-level nodes</p>
-    <div>
-      <JSONTree
-        collectionLimit={100}
-        data={Array.from({ length: 10000 }).map((_, i) => ({
-          name: `item #${i}`,
-          value: i,
-        }))}
-      />
+        <p>Collapsed top-level nodes</p>
+        <div>
+            <JSONTree
+                collectionLimit={100}
+                data={Array.from({length: 10000}).map((_, i) => ({
+                    name: `item #${i}`,
+                    value: i,
+                }))}
+            />
+        </div>
     </div>
-  </div>
 );
 
 export default App;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gtk-grafana/react-json-tree",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "React JSON Viewer Component, Extracted from redux-devtools",
   "keywords": [
     "react",

--- a/src/JSONNestedNode.tsx
+++ b/src/JSONNestedNode.tsx
@@ -105,6 +105,7 @@ export default function JSONNestedNode(props: Props) {
     expandable,
     getItemString,
     hideRoot,
+    hideRootExpand,
     isCircular,
     keyPath,
     labelRenderer,
@@ -114,14 +115,18 @@ export default function JSONNestedNode(props: Props) {
     shouldExpandNodeInitially,
   } = props;
 
+  const isRoot = keyPath[0] === "root"
+  const showExpand = hideRootExpand ? expandable && !isRoot && hideRootExpand : expandable
+  const isNodeExpandable = expandable && showExpand
+
   const [expanded, setExpanded] = useState<boolean>(
     // calculate individual node expansion if necessary
     isCircular ? false : shouldExpandNodeInitially(keyPath, data, level),
   );
 
   const handleClick = useCallback(() => {
-    if (expandable) setExpanded(!expanded);
-  }, [expandable, expanded]);
+    if (isNodeExpandable) setExpanded(!expanded);
+  }, [isNodeExpandable, expanded]);
 
   const renderedChildren =
     expanded || (hideRoot && level === 0)
@@ -142,11 +147,11 @@ export default function JSONNestedNode(props: Props) {
     createItemString(data, collectionLimit),
     keyPath,
   );
-  const stylingArgs = [keyPath, nodeType, expanded, expandable] as const;
+  const stylingArgs = [keyPath, nodeType, expanded, isNodeExpandable] as const;
 
   return hideRoot ? (
     <NodeListItem
-      expandable={expandable}
+      expandable={isNodeExpandable}
       expanded={expanded}
       nodeType={nodeType}
       keyPath={keyPath}
@@ -156,14 +161,14 @@ export default function JSONNestedNode(props: Props) {
     </NodeListItem>
   ) : (
     <NodeListItem
-      expandable={expandable}
+      expandable={isNodeExpandable}
       expanded={expanded}
       nodeType={nodeType}
       keyPath={keyPath}
-      className={`${styles.nestedNode}  ${expanded ? styles.nestedNodeExpanded : ""} ${expandable ? styles.nestedNodeExpandable : ""}`}
+      className={`${styles.nestedNode}  ${expanded ? styles.nestedNodeExpanded : ""} ${isNodeExpandable ? styles.nestedNodeExpandable : ""}`}
     >
       <span className={styles.nestedNodeLabelWrap}>
-        {expandable && (
+        {showExpand && (
           <JSONArrow
             nodeType={nodeType}
             expanded={expanded}
@@ -173,7 +178,7 @@ export default function JSONNestedNode(props: Props) {
         <span
           data-nodetype={nodeType}
           data-keypath={keyPath[0]}
-          className={`${styles.nestedNodeLabel} ${expanded ? styles.nestedNodeLabelExpanded : ""} ${expandable ? styles.nestedNodeLabelExpandable : ""}`}
+          className={`${styles.nestedNodeLabel} ${expanded ? styles.nestedNodeLabelExpanded : ""} ${isNodeExpandable ? styles.nestedNodeLabelExpandable : ""}`}
           onClick={handleClick}
         >
           {labelRenderer(...stylingArgs)}

--- a/src/JSONNestedNode.tsx
+++ b/src/JSONNestedNode.tsx
@@ -115,9 +115,11 @@ export default function JSONNestedNode(props: Props) {
     shouldExpandNodeInitially,
   } = props;
 
-  const isRoot = keyPath[0] === "root"
-  const showExpand = hideRootExpand ? expandable && !isRoot && hideRootExpand : expandable
-  const isNodeExpandable = expandable && showExpand
+  const isRoot = keyPath[0] === "root";
+  const showExpand = hideRootExpand
+    ? expandable && !isRoot && hideRootExpand
+    : expandable;
+  const isNodeExpandable = expandable && showExpand;
 
   const [expanded, setExpanded] = useState<boolean>(
     // calculate individual node expansion if necessary

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -40,6 +40,7 @@ export function JSONTree({
   valueRenderer = identity,
   shouldExpandNodeInitially = expandRootNode,
   hideRoot = false,
+  hideRootExpand = false,
   getItemString = defaultItemString,
   postprocessValue = identity,
   isCustomNode = noCustomNode,
@@ -54,6 +55,7 @@ export function JSONTree({
       className={styles.tree}
     >
       <JSONNode
+        hideRootExpand={hideRootExpand}
         keyPath={hideRoot ? [] : keyPath}
         value={postprocessValue(value)}
         isCustomNode={isCustomNode}

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,7 @@ export interface CommonExternalProps {
   valueRenderer: ValueRenderer;
   shouldExpandNodeInitially: ShouldExpandNodeInitially;
   hideRoot: boolean;
+  hideRootExpand: boolean
   getItemString: GetItemString;
   postprocessValue: PostprocessValue;
   isCustomNode: IsCustomNode;

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,7 @@ export interface CommonExternalProps {
   valueRenderer: ValueRenderer;
   shouldExpandNodeInitially: ShouldExpandNodeInitially;
   hideRoot: boolean;
-  hideRootExpand: boolean
+  hideRootExpand: boolean;
   getItemString: GetItemString;
   postprocessValue: PostprocessValue;
   isCustomNode: IsCustomNode;


### PR DESCRIPTION
Allow the root node to be visualized, but don't allow users to collapse the root on click, and hide the arrow