### PR TITLE
Gtk grafana/scroll into view fix

### DIFF
--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Map } from "immutable";
 import { JSONTree, KeyPath, areKeyPathsEqual } from "react-json-tree";
-import { ScrollToPath } from "../../src/types";
+import {ScrollToPath} from "../../src/types";
 
 const getItemString = (type: string) => (
   <span>
@@ -71,7 +71,9 @@ const data: Record<string, any> = {
     { objectKey: "value1" },
     { objectKey: "value2" },
   ]),
-  hugeArray: Array.from({ length: 10000 }).map((_, i) => `item #${i}`),
+  hugeArray: {
+      'array': Array.from({ length: 10000 }).map((_, i) => `item #${i}`),
+  },
   hugeObject: Object.create(
     Array.from({ length: 10000 }).map((_, i) => `item #${i}`),
   ),
@@ -84,7 +86,7 @@ const data: Record<string, any> = {
 
 // Should not throw error
 const key: KeyPath = [];
-const hugeArrayKeyPath: ScrollToPath = [101, "hugeArray", "root"];
+const hugeArrayKeyPath: ScrollToPath = [101, 'array', "hugeArray", "root"];
 
 const App = () => (
   <div style={{ background: "#fff" }}>
@@ -95,15 +97,15 @@ const App = () => (
     <br />
 
     <h3>Scroll to on render example</h3>
-    <div style={{ background: "#222" }}>
+    <div style={{ background: "#222", height: "800px", overflow: "auto" }}>
       <JSONTree
         data={data}
         shouldExpandNodeInitially={(keyPath: KeyPath) => {
-          // Caller needs to ensure that parent node of scrollToPath is expanded for scrollTo to work on initial render, otherwise it will scroll to when the parent node/collection is expanded
-          return !!areKeyPathsEqual(
-            keyPath,
-            hugeArrayKeyPath.slice(keyPath.length * -1),
-          );
+            // Caller needs to ensure that parent node of scrollToPath is expanded for scrollTo to work on initial render, otherwise it will scroll to when the parent node/collection is expanded
+            return !!areKeyPathsEqual(
+                keyPath,
+                hugeArrayKeyPath.slice( keyPath.length * -1),
+            );
         }}
         scrollToPath={hugeArrayKeyPath}
       />

--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -97,7 +97,14 @@ const App = () => (
     <br />
 
     <h3>Scroll to on render example</h3>
-    <div style={{ background: "#222", height: "800px", overflow: "auto", scrollBehavior: "smooth" }}>
+    <div
+      style={{
+        background: "#222",
+        height: "800px",
+        overflow: "auto",
+        scrollBehavior: "smooth",
+      }}
+    >
       <JSONTree
         data={data}
         shouldExpandNodeInitially={(keyPath: KeyPath) => {

--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Map } from "immutable";
 import { JSONTree, KeyPath, areKeyPathsEqual } from "react-json-tree";
-import {ScrollToPath} from "../../src/types";
+import { ScrollToPath } from "../../src/types";
 
 const getItemString = (type: string) => (
   <span>
@@ -72,7 +72,7 @@ const data: Record<string, any> = {
     { objectKey: "value2" },
   ]),
   hugeArray: {
-      'array': Array.from({ length: 10000 }).map((_, i) => `item #${i}`),
+    array: Array.from({ length: 10000 }).map((_, i) => `item #${i}`),
   },
   hugeObject: Object.create(
     Array.from({ length: 10000 }).map((_, i) => `item #${i}`),
@@ -86,7 +86,7 @@ const data: Record<string, any> = {
 
 // Should not throw error
 const key: KeyPath = [];
-const hugeArrayKeyPath: ScrollToPath = [101, 'array', "hugeArray", "root"];
+const hugeArrayKeyPath: ScrollToPath = [101, "array", "hugeArray", "root"];
 
 const App = () => (
   <div style={{ background: "#fff" }}>
@@ -97,15 +97,15 @@ const App = () => (
     <br />
 
     <h3>Scroll to on render example</h3>
-    <div style={{ background: "#222", height: "800px", overflow: "auto" }}>
+    <div style={{ background: "#222", height: "800px", overflow: "auto", scrollBehavior: "smooth" }}>
       <JSONTree
         data={data}
         shouldExpandNodeInitially={(keyPath: KeyPath) => {
-            // Caller needs to ensure that parent node of scrollToPath is expanded for scrollTo to work on initial render, otherwise it will scroll to when the parent node/collection is expanded
-            return !!areKeyPathsEqual(
-                keyPath,
-                hugeArrayKeyPath.slice( keyPath.length * -1),
-            );
+          // Caller needs to ensure that parent node of scrollToPath is expanded for scrollTo to work on initial render, otherwise it will scroll to when the parent node/collection is expanded
+          return !!areKeyPathsEqual(
+            keyPath,
+            hugeArrayKeyPath.slice(keyPath.length * -1),
+          );
         }}
         scrollToPath={hugeArrayKeyPath}
       />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gtk-grafana/react-json-tree",
-  "version": "0.0.16",
+  "version": "0.0.12",
   "description": "React JSON Viewer Component, Extracted from redux-devtools",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gtk-grafana/react-json-tree",
-  "version": "0.0.11",
+  "version": "0.0.16",
   "description": "React JSON Viewer Component, Extracted from redux-devtools",
   "keywords": [
     "react",

--- a/src/ItemRange.tsx
+++ b/src/ItemRange.tsx
@@ -1,6 +1,11 @@
 import React, { useCallback, useState } from "react";
 import JSONArrow from "./JSONArrow.js";
-import {CircularCache, CommonInternalProps, KeyPath, ScrollToPath} from "./types.js";
+import {
+  CircularCache,
+  CommonInternalProps,
+  KeyPath,
+  ScrollToPath,
+} from "./types.js";
 import styles from "./styles/itemRange.module.scss";
 import { areKeyPathsEqual } from "./index.tsx";
 
@@ -20,7 +25,11 @@ export default function ItemRange(props: Props) {
   let initialExpanded = false;
   if (scrollToPath) {
     const [index] = scrollToPath;
-    if (areKeyPathsEqual(scrollToPath.slice(keyPath.length * -1), keyPath) && index > from && index <= to) {
+    if (
+      areKeyPathsEqual(scrollToPath.slice(keyPath.length * -1), keyPath) &&
+      index > from &&
+      index <= to
+    ) {
       initialExpanded = true;
     }
   }

--- a/src/ItemRange.tsx
+++ b/src/ItemRange.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from "react";
 import JSONArrow from "./JSONArrow.js";
-import { CircularCache, CommonInternalProps, ScrollToPath } from "./types.js";
+import {CircularCache, CommonInternalProps, KeyPath, ScrollToPath} from "./types.js";
 import styles from "./styles/itemRange.module.scss";
 import { areKeyPathsEqual } from "./index.tsx";
 
@@ -19,8 +19,8 @@ export default function ItemRange(props: Props) {
   const { from, to, renderChildNodes, nodeType, scrollToPath, keyPath } = props;
   let initialExpanded = false;
   if (scrollToPath) {
-    const [index, ...path] = scrollToPath;
-    if (areKeyPathsEqual(path, keyPath) && index > from && index <= to) {
+    const [index] = scrollToPath;
+    if (areKeyPathsEqual(scrollToPath.slice(keyPath.length * -1), keyPath) && index > from && index <= to) {
       initialExpanded = true;
     }
   }

--- a/src/JSONValueNode.tsx
+++ b/src/JSONValueNode.tsx
@@ -34,7 +34,8 @@ export default function JSONValueNode({
   scrollToPath,
 }: Props) {
   const ref = React.useRef<HTMLLIElement>(null);
-  const isScrollTo = scrollToPath !== undefined && areKeyPathsEqual(scrollToPath, keyPath)
+  const isScrollTo =
+    scrollToPath !== undefined && areKeyPathsEqual(scrollToPath, keyPath);
 
   React.useEffect(() => {
     if (ref.current) {
@@ -42,14 +43,11 @@ export default function JSONValueNode({
     }
   }, []);
 
-  const optionalProps =
-      isScrollTo
-      ? { ref, "data-scrolled": "true" }
-      : {};
+  const optionalProps = isScrollTo ? { ref, "data-scrolled": "true" } : {};
 
   return (
     <li
-      className={`${styles.valueNode} valueNode--${nodeType} valueNode--${keyPath[0]} ${isScrollTo ? styles.valueNodeScrolled : ''}`}
+      className={`${styles.valueNode} valueNode--${nodeType} valueNode--${keyPath[0]} ${isScrollTo ? styles.valueNodeScrolled : ""}`}
       {...optionalProps}
     >
       <span className={styles.valueNodeLabel}>

--- a/src/JSONValueNode.tsx
+++ b/src/JSONValueNode.tsx
@@ -34,27 +34,28 @@ export default function JSONValueNode({
   scrollToPath,
 }: Props) {
   const ref = React.useRef<HTMLLIElement>(null);
+  const isScrollTo = scrollToPath !== undefined && areKeyPathsEqual(scrollToPath, keyPath)
 
   React.useEffect(() => {
     if (ref.current) {
-      ref.current.scrollIntoView({ behavior: "smooth" });
+      ref.current.scrollIntoView({ behavior: "auto" });
     }
   }, []);
 
   const optionalProps =
-    scrollToPath !== undefined && areKeyPathsEqual(scrollToPath, keyPath)
-      ? { ref }
+      isScrollTo
+      ? { ref, "data-scrolled": "true" }
       : {};
 
   return (
     <li
-      className={`${styles.valueNode} valueNode--${nodeType} valueNode--${keyPath[0]}`}
+      className={`${styles.valueNode} valueNode--${nodeType} valueNode--${keyPath[0]} ${isScrollTo ? styles.valueNodeScrolled : ''}`}
       {...optionalProps}
     >
-      <span data-testid={"value-node-label"} className={styles.valueNodeLabel}>
+      <span className={styles.valueNodeLabel}>
         {labelRenderer(keyPath, nodeType, false, false)}
       </span>
-      <span data-testid={"value-node-value"} className={styles.valueNodeValue}>
+      <span className={styles.valueNodeValue}>
         {valueRenderer(
           valueGetter ? valueGetter(value) : undefined,
           value,

--- a/src/components/NodeListItem.module.scss
+++ b/src/components/NodeListItem.module.scss
@@ -1,0 +1,3 @@
+.nodeListItemScrolled {
+  scroll-margin: var(--json-tree-scroll-margin);
+}

--- a/src/components/NodeListItem.tsx
+++ b/src/components/NodeListItem.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import {areKeyPathsEqual, KeyPath} from "../main.ts";
+import { areKeyPathsEqual, KeyPath } from "../main.ts";
+import styles from './NodeListItem.module.scss'
 
 interface ListItemProps {
   expanded: boolean;
@@ -18,20 +19,21 @@ export const NodeListItem = ({
   nodeType,
   keyPath,
   className,
-  scrollToPath
+  scrollToPath,
 }: ListItemProps) => {
   const ref = React.useRef<HTMLLIElement>(null);
+  const isScrollTo = scrollToPath !== undefined && areKeyPathsEqual(scrollToPath, keyPath)
 
   React.useEffect(() => {
     if (ref.current) {
-      ref.current.scrollIntoView({ behavior: "smooth", inline: 'start' });
+      ref.current.scrollIntoView({ behavior: "auto" });
     }
   }, []);
 
   const optionalProps =
-      scrollToPath !== undefined && areKeyPathsEqual(scrollToPath, keyPath)
-          ? { ref, 'data-scrolled': 'true' }
-          : {};
+      isScrollTo
+      ? { ref, "data-scrolled": "true" }
+      : {};
 
   // aria-expanded is only wanted on elements that have expanded state, for un-expandable nodes we want to omit the attribute all together
   if (expandable) {
@@ -42,7 +44,7 @@ export const NodeListItem = ({
         data-nodetype={nodeType}
         data-keypath={keyPath[0]}
         aria-label={keyPath[0]?.toString()}
-        className={className}
+        className={`${className} ${isScrollTo ? styles.nodeListItemScrolled : ''}`}
         {...optionalProps}
       >
         {children}

--- a/src/components/NodeListItem.tsx
+++ b/src/components/NodeListItem.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { areKeyPathsEqual, KeyPath } from "../main.ts";
-import styles from './NodeListItem.module.scss'
+import styles from "./NodeListItem.module.scss";
 
 interface ListItemProps {
   expanded: boolean;
@@ -22,7 +22,8 @@ export const NodeListItem = ({
   scrollToPath,
 }: ListItemProps) => {
   const ref = React.useRef<HTMLLIElement>(null);
-  const isScrollTo = scrollToPath !== undefined && areKeyPathsEqual(scrollToPath, keyPath)
+  const isScrollTo =
+    scrollToPath !== undefined && areKeyPathsEqual(scrollToPath, keyPath);
 
   React.useEffect(() => {
     if (ref.current) {
@@ -30,10 +31,7 @@ export const NodeListItem = ({
     }
   }, []);
 
-  const optionalProps =
-      isScrollTo
-      ? { ref, "data-scrolled": "true" }
-      : {};
+  const optionalProps = isScrollTo ? { ref, "data-scrolled": "true" } : {};
 
   // aria-expanded is only wanted on elements that have expanded state, for un-expandable nodes we want to omit the attribute all together
   if (expandable) {
@@ -44,7 +42,7 @@ export const NodeListItem = ({
         data-nodetype={nodeType}
         data-keypath={keyPath[0]}
         aria-label={keyPath[0]?.toString()}
-        className={`${className} ${isScrollTo ? styles.nodeListItemScrolled : ''}`}
+        className={`${className} ${isScrollTo ? styles.nodeListItemScrolled : ""}`}
         {...optionalProps}
       >
         {children}

--- a/src/components/NodeListItem.tsx
+++ b/src/components/NodeListItem.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { KeyPath } from "../main.ts";
-import { ScrollToPath } from "../types.ts";
+import {areKeyPathsEqual, KeyPath} from "../main.ts";
 
 interface ListItemProps {
   expanded: boolean;
@@ -9,7 +8,7 @@ interface ListItemProps {
   keyPath: KeyPath;
   className: string;
   children: React.ReactNode;
-  scrollToPath?: ScrollToPath;
+  scrollToPath?: KeyPath;
 }
 
 export const NodeListItem = ({
@@ -19,7 +18,21 @@ export const NodeListItem = ({
   nodeType,
   keyPath,
   className,
+  scrollToPath
 }: ListItemProps) => {
+  const ref = React.useRef<HTMLLIElement>(null);
+
+  React.useEffect(() => {
+    if (ref.current) {
+      ref.current.scrollIntoView({ behavior: "smooth", inline: 'start' });
+    }
+  }, []);
+
+  const optionalProps =
+      scrollToPath !== undefined && areKeyPathsEqual(scrollToPath, keyPath)
+          ? { ref, 'data-scrolled': 'true' }
+          : {};
+
   // aria-expanded is only wanted on elements that have expanded state, for un-expandable nodes we want to omit the attribute all together
   if (expandable) {
     return (
@@ -30,6 +43,7 @@ export const NodeListItem = ({
         data-keypath={keyPath[0]}
         aria-label={keyPath[0]?.toString()}
         className={className}
+        {...optionalProps}
       >
         {children}
       </li>
@@ -42,6 +56,7 @@ export const NodeListItem = ({
         data-keypath={keyPath[0]}
         aria-label={keyPath[0]?.toString()}
         className={className}
+        {...optionalProps}
       >
         {children}
       </li>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,6 @@
 // port by Daniele Zannotti http://www.github.com/dzannotti <dzannotti@me.com>
 import JSONNode from "./JSONNode.js";
 import type {
-  CommonExternalProps,
   GetItemString,
   IsCustomNode,
   JSONTreeProps,

--- a/src/styles/JSONValueNode.module.scss
+++ b/src/styles/JSONValueNode.module.scss
@@ -14,3 +14,7 @@
   margin-right: var(--json-tree-value-label-margin);
   display: var(--json-tree-inline-flex);
 }
+
+.valueNodeScrolled {
+  scroll-margin: var(--json-tree-scroll-margin);
+}

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -51,4 +51,7 @@
   --json-tree-label-value-color: rgb(249, 38, 114);
   --json-tree-arrow-color: var(--json-tree-label-color);
   --json-tree-transition-timing: 150ms;
+
+  /** Scroll behavior **/
+  --json-tree-scroll-margin: 0;
 }


### PR DESCRIPTION
Follow up to https://github.com/gtk-grafana/react-json-tree/pull/21.
#21 didn't work on nested nodes, only value nodes.
Adds support for customizing scroll behavior via `scroll-behavior` css by setting `scrollIntoView` behavior as auto.
Adds support for customzining scroll offset via `--json-tree-scroll-margin` css variable.
