### PR TITLE
[FEAT]: onExpand callback

### DIFF
--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -1,7 +1,12 @@
 import React from "react";
 import { Map } from "immutable";
-import { JSONTree, KeyPath, areKeyPathsEqual, doesNodeContainNode, ScrollToPath } from "react-json-tree";
-
+import {
+  JSONTree,
+  KeyPath,
+  areKeyPathsEqual,
+  doesNodeContainNode,
+  ScrollToPath,
+} from "react-json-tree";
 
 const getItemString = (type: string) => (
   <span>
@@ -31,24 +36,26 @@ const data: Record<string, any> = {
   bool: true,
   date: new Date(),
   error: new Error(longString),
-  arrayOfObjects: [Array.from({ length: 1000 }).map(e => ({
+  arrayOfObjects: [
+    Array.from({ length: 1000 }).map((e) => ({
       foo: {
-          bar: "baz",
-          nested: {
-              bar: "baz2",
-              moreNested: {
-                  bar: "baz3",
-                  evenMoreNested: {
-                      veryNested: {
-                          insanelyNested: {
-                              ridiculouslyDeepValue: "Hello",
-                          },
-                      },
-                  },
+        bar: "baz",
+        nested: {
+          bar: "baz2",
+          moreNested: {
+            bar: "baz3",
+            evenMoreNested: {
+              veryNested: {
+                insanelyNested: {
+                  ridiculouslyDeepValue: "Hello",
+                },
               },
+            },
           },
+        },
       },
-  }))],
+    })),
+  ],
   object: {
     foo: {
       bar: "baz",
@@ -106,203 +113,210 @@ const data: Record<string, any> = {
 const key: KeyPath = [];
 const hugeArrayKeyPath: ScrollToPath = [101, "array", "hugeArray", "root"];
 
-
 const App = () => (
-  <div style={{background: "#fff"}}>
-      <h3>Basic Example</h3>
-      <div style={{background: "#222"}}>
-          <JSONTree data={data}/>
-      </div>
-      <br/>
+  <div style={{ background: "#fff" }}>
+    <h3>Basic Example</h3>
+    <div style={{ background: "#222" }}>
+      <JSONTree data={data} />
+    </div>
+    <br />
 
-      <h3>Scroll to on render example</h3>
-      <div
-          style={{
-              background: "#222",
-              height: "800px",
-              overflow: "auto",
-              scrollBehavior: "smooth",
-          }}
-      >
-          <JSONTree
-              data={data}
-              // @todo don't commit
-              // shouldExpandNodeInitially={(keyPath: KeyPath) => {
-              //     // Caller needs to ensure that parent node of scrollToPath is expanded for scrollTo to work on initial render, otherwise it will scroll to when the parent node/collection is expanded
-              //     return !!areKeyPathsEqual(
-              //         keyPath,
-              //         hugeArrayKeyPath.slice(keyPath.length * -1),
-              //     );
-              // }}
-              scrollToPath={hugeArrayKeyPath}
-          />
-      </div>
-      <br/>
+    <h3>Scroll to on render example</h3>
+    <div
+      style={{
+        background: "#222",
+        height: "800px",
+        overflow: "auto",
+        scrollBehavior: "smooth",
+      }}
+    >
+      <JSONTree
+        data={data}
+        // @todo don't commit
+        // shouldExpandNodeInitially={(keyPath: KeyPath) => {
+        //     // Caller needs to ensure that parent node of scrollToPath is expanded for scrollTo to work on initial render, otherwise it will scroll to when the parent node/collection is expanded
+        //     return !!areKeyPathsEqual(
+        //         keyPath,
+        //         hugeArrayKeyPath.slice(keyPath.length * -1),
+        //     );
+        // }}
+        scrollToPath={hugeArrayKeyPath}
+      />
+    </div>
+    <br />
 
-      <h3>Scroll to on open example</h3>
-      <div style={{background: "#222"}}>
-          <JSONTree data={data} scrollToPath={hugeArrayKeyPath}/>
-      </div>
-      <br/>
+    <h3>Scroll to on open example</h3>
+    <div style={{ background: "#222" }}>
+      <JSONTree data={data} scrollToPath={hugeArrayKeyPath} />
+    </div>
+    <br />
 
-      <h3>Hide root node</h3>
-      <div style={{background: "#222"}}>
-          <JSONTree hideRoot={true} data={data}/>
-      </div>
-      <br/>
+    <h3>Hide root node</h3>
+    <div style={{ background: "#222" }}>
+      <JSONTree hideRoot={true} data={data} />
+    </div>
+    <br />
 
-      <h3>Force root node open</h3>
-      <div style={{background: "#222"}}>
-          <JSONTree hideRootExpand={true} data={data}/>
-      </div>
-      <br/>
+    <h3>Force root node open</h3>
+    <div style={{ background: "#222" }}>
+      <JSONTree hideRootExpand={true} data={data} />
+    </div>
+    <br />
 
-      <h3>No quotations around string values</h3>
-      <div style={{background: "#222"}}>
-          <JSONTree valueWrap={""} data={data}/>
-      </div>
-      <br/>
+    <h3>No quotations around string values</h3>
+    <div style={{ background: "#222" }}>
+      <JSONTree valueWrap={""} data={data} />
+    </div>
+    <br />
 
-      <h3>Theming Example</h3>
-      <p>
-          Styles are managed with css variables, override the default values to
-          customize.
-      </p>
-      <div
-          style={
-              {
-                  "--json-tree-label-color": "rgb(12, 127, 149)",
-                  "--json-tree-key-label-color": "rgb(71, 131, 0)",
-                  "--json-tree-label-value-color": "rgb(255, 48, 124)",
-                  "--json-tree-arrow-color": "rgb(12, 127, 149)",
-                  "--json-tree-value-text-wrap": "nowrap",
-              } as React.CSSProperties
-          }
-      >
-          <JSONTree data={data}/>
-      </div>
+    <h3>Theming Example</h3>
+    <p>
+      Styles are managed with css variables, override the default values to
+      customize.
+    </p>
+    <div
+      style={
+        {
+          "--json-tree-label-color": "rgb(12, 127, 149)",
+          "--json-tree-key-label-color": "rgb(71, 131, 0)",
+          "--json-tree-label-value-color": "rgb(255, 48, 124)",
+          "--json-tree-arrow-color": "rgb(12, 127, 149)",
+          "--json-tree-value-text-wrap": "nowrap",
+        } as React.CSSProperties
+      }
+    >
+      <JSONTree data={data} />
+    </div>
 
-      <h3>Theming Example - relative position arrows</h3>
-      <p>
-          Styles are managed with css variables, override the default values to
-          customize.
-      </p>
-      <div
-          style={
-              {
-                  "--json-tree-label-color": "rgb(12, 127, 149)",
-                  "--json-tree-key-label-color": "rgb(71, 131, 0)",
-                  "--json-tree-label-value-color": "rgb(255, 48, 124)",
-                  "--json-tree-arrow-color": "rgb(12, 127, 149)",
-                  "--json-tree-arrow-position": "relative",
-                  "--json-tree-ul-root-padding": "0",
-                  "--json-tree-arrow-left-offset": "0",
-                  "--json-tree-arrow-right-margin": "0.5em",
-              } as React.CSSProperties
-          }
-      >
-          <JSONTree data={data}/>
-      </div>
+    <h3>Theming Example - relative position arrows</h3>
+    <p>
+      Styles are managed with css variables, override the default values to
+      customize.
+    </p>
+    <div
+      style={
+        {
+          "--json-tree-label-color": "rgb(12, 127, 149)",
+          "--json-tree-key-label-color": "rgb(71, 131, 0)",
+          "--json-tree-label-value-color": "rgb(255, 48, 124)",
+          "--json-tree-arrow-color": "rgb(12, 127, 149)",
+          "--json-tree-arrow-position": "relative",
+          "--json-tree-ul-root-padding": "0",
+          "--json-tree-arrow-left-offset": "0",
+          "--json-tree-arrow-right-margin": "0.5em",
+        } as React.CSSProperties
+      }
+    >
+      <JSONTree data={data} />
+    </div>
 
-      <h3>Style Customization</h3>
-      <ul>
-          <li>
-              Label changes between uppercase/lowercase based on the expanded state.
-          </li>
-          <li>Array keys are styled based on their parity.</li>
-          <li>
-              The labels of objects, arrays, and iterables are customized as &quot;//
-              type&quot;.
-          </li>
-          <li>See code for details.</li>
-      </ul>
-      <div>
-          <JSONTree data={data} getItemString={getItemString}/>
-      </div>
-      <h3>More Fine Grained Rendering</h3>
-      <p>
-          Pass <code>labelRenderer</code> or <code>valueRenderer</code>.
-      </p>
-      <div>
-          <JSONTree
-              data={data}
-              labelRenderer={([raw]) => <span>(({raw})):</span>}
-              valueRenderer={(raw) => (
-                  <em>
+    <h3>Style Customization</h3>
+    <ul>
+      <li>
+        Label changes between uppercase/lowercase based on the expanded state.
+      </li>
+      <li>Array keys are styled based on their parity.</li>
+      <li>
+        The labels of objects, arrays, and iterables are customized as &quot;//
+        type&quot;.
+      </li>
+      <li>See code for details.</li>
+    </ul>
+    <div>
+      <JSONTree data={data} getItemString={getItemString} />
+    </div>
+    <h3>More Fine Grained Rendering</h3>
+    <p>
+      Pass <code>labelRenderer</code> or <code>valueRenderer</code>.
+    </p>
+    <div>
+      <JSONTree
+        data={data}
+        labelRenderer={([raw]) => <span>(({raw})):</span>}
+        valueRenderer={(raw) => (
+          <em>
             <span role="img" aria-label="mellow">
               😐
             </span>{" "}
-                      {raw as string}{" "}
-                      <span role="img" aria-label="mellow">
+            {raw as string}{" "}
+            <span role="img" aria-label="mellow">
               😐
             </span>
-                  </em>
-              )}
-          />
-      </div>
-      <p>
-          Sort object keys with <code>sortObjectKeys</code> prop.
-      </p>
-      <div>
-          <JSONTree data={data} sortObjectKeys/>
-      </div>
-      <p>Collapsed root node</p>
-      <div>
-          <JSONTree data={data} shouldExpandNodeInitially={() => false}/>
-      </div>
+          </em>
+        )}
+      />
+    </div>
+    <p>
+      Sort object keys with <code>sortObjectKeys</code> prop.
+    </p>
+    <div>
+      <JSONTree data={data} sortObjectKeys />
+    </div>
+    <p>Collapsed root node</p>
+    <div>
+      <JSONTree data={data} shouldExpandNodeInitially={() => false} />
+    </div>
 
-      <p>Collapsed top-level nodes</p>
-      <div>
-          <JSONTree
-              collectionLimit={100}
-              data={Array.from({length: 10000}).map((_, i) => ({
-                  name: `item #${i}`,
-                  value: i,
-              }))}
-          />
-      </div>
+    <p>Collapsed top-level nodes</p>
+    <div>
+      <JSONTree
+        collectionLimit={100}
+        data={Array.from({ length: 10000 }).map((_, i) => ({
+          name: `item #${i}`,
+          value: i,
+        }))}
+      />
+    </div>
 
-      <h3>Shift + click to toggle visualizing all child nodes</h3>
-      <div style={{background: "#222"}}>
-          <OnExpandExample />
-      </div>
-      <br/>
-
+    <h3>Shift + click to toggle visualizing all child nodes</h3>
+    <div style={{ background: "#222" }}>
+      <OnExpandExample />
+    </div>
+    <br />
   </div>
 );
 
 function OnExpandExample() {
-    const [keyPathsToExpand, setKeyPathsToExpand] = React.useState<KeyPath[]>([])
-    return <div>
-        <div style={{color: 'white'}}>
-            KeyPaths that will be expanded: {JSON.stringify(keyPathsToExpand)}
-        </div>
+  const [keyPathsToExpand, setKeyPathsToExpand] = React.useState<KeyPath[]>([]);
+  return (
+    <div>
+      <div style={{ color: "white" }}>
+        KeyPaths that will be expanded: {JSON.stringify(keyPathsToExpand)}
+      </div>
 
-        <JSONTree
-            shouldExpandNodeInitially={(keyPath, data, level) => {
-                for(let i = 0; i < keyPathsToExpand.length; i++) {
-                    if(doesNodeContainNode(keyPathsToExpand[i], keyPath)) {
-                        return true;
-                    }
-                }
-
-                return level < 1
-            }}
-            data={data}
-            onExpand={(e, keyPath, expanded) => {
-            if ((e.ctrlKey || e.shiftKey || e.altKey)) {
-                if(expanded){
-                    setKeyPathsToExpand([...keyPathsToExpand.filter(existingKeyPath => !areKeyPathsEqual(existingKeyPath, keyPath)), keyPath])
-                }else {
-                    if(keyPathsToExpand.length) {
-                        setKeyPathsToExpand(keyPathsToExpand.filter(k => !areKeyPathsEqual(k, keyPath)))
-                    }
-                }
-
+      <JSONTree
+        shouldExpandNodeInitially={(keyPath, data, level) => {
+          for (let i = 0; i < keyPathsToExpand.length; i++) {
+            if (doesNodeContainNode(keyPathsToExpand[i], keyPath)) {
+              return true;
             }
-        }}/>
-    </div>;
-}
+          }
 
+          return level < 1;
+        }}
+        data={data}
+        onExpand={(e, keyPath, expanded) => {
+          if (e.ctrlKey || e.shiftKey || e.altKey) {
+            if (expanded) {
+              setKeyPathsToExpand([
+                ...keyPathsToExpand.filter(
+                  (existingKeyPath) =>
+                    !areKeyPathsEqual(existingKeyPath, keyPath),
+                ),
+                keyPath,
+              ]);
+            } else {
+              if (keyPathsToExpand.length) {
+                setKeyPathsToExpand(
+                  keyPathsToExpand.filter((k) => !areKeyPathsEqual(k, keyPath)),
+                );
+              }
+            }
+          }
+        }}
+      />
+    </div>
+  );
+}
 
 export default App;

--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Map } from "immutable";
-import { JSONTree, KeyPath, areKeyPathsEqual } from "react-json-tree";
-import { ScrollToPath } from "../../src/types";
+import { JSONTree, KeyPath, areKeyPathsEqual, doesNodeContainNode, ScrollToPath } from "react-json-tree";
+
 
 const getItemString = (type: string) => (
   <span>
@@ -31,6 +31,24 @@ const data: Record<string, any> = {
   bool: true,
   date: new Date(),
   error: new Error(longString),
+  arrayOfObjects: [Array.from({ length: 1000 }).map(e => ({
+      foo: {
+          bar: "baz",
+          nested: {
+              bar: "baz2",
+              moreNested: {
+                  bar: "baz3",
+                  evenMoreNested: {
+                      veryNested: {
+                          insanelyNested: {
+                              ridiculouslyDeepValue: "Hello",
+                          },
+                      },
+                  },
+              },
+          },
+      },
+  }))],
   object: {
     foo: {
       bar: "baz",
@@ -88,160 +106,203 @@ const data: Record<string, any> = {
 const key: KeyPath = [];
 const hugeArrayKeyPath: ScrollToPath = [101, "array", "hugeArray", "root"];
 
+
 const App = () => (
-  <div style={{ background: "#fff" }}>
-    <h3>Basic Example</h3>
-    <div style={{ background: "#222" }}>
-      <JSONTree data={data} />
-    </div>
-    <br />
+  <div style={{background: "#fff"}}>
+      <h3>Basic Example</h3>
+      <div style={{background: "#222"}}>
+          <JSONTree data={data}/>
+      </div>
+      <br/>
 
-    <h3>Scroll to on render example</h3>
-    <div
-      style={{
-        background: "#222",
-        height: "800px",
-        overflow: "auto",
-        scrollBehavior: "smooth",
-      }}
-    >
-      <JSONTree
-        data={data}
-        shouldExpandNodeInitially={(keyPath: KeyPath) => {
-          // Caller needs to ensure that parent node of scrollToPath is expanded for scrollTo to work on initial render, otherwise it will scroll to when the parent node/collection is expanded
-          return !!areKeyPathsEqual(
-            keyPath,
-            hugeArrayKeyPath.slice(keyPath.length * -1),
-          );
-        }}
-        scrollToPath={hugeArrayKeyPath}
-      />
-    </div>
-    <br />
+      <h3>Scroll to on render example</h3>
+      <div
+          style={{
+              background: "#222",
+              height: "800px",
+              overflow: "auto",
+              scrollBehavior: "smooth",
+          }}
+      >
+          <JSONTree
+              data={data}
+              // @todo don't commit
+              // shouldExpandNodeInitially={(keyPath: KeyPath) => {
+              //     // Caller needs to ensure that parent node of scrollToPath is expanded for scrollTo to work on initial render, otherwise it will scroll to when the parent node/collection is expanded
+              //     return !!areKeyPathsEqual(
+              //         keyPath,
+              //         hugeArrayKeyPath.slice(keyPath.length * -1),
+              //     );
+              // }}
+              scrollToPath={hugeArrayKeyPath}
+          />
+      </div>
+      <br/>
 
-    <h3>Scroll to on open example</h3>
-    <div style={{ background: "#222" }}>
-      <JSONTree data={data} scrollToPath={hugeArrayKeyPath} />
-    </div>
-    <br />
+      <h3>Scroll to on open example</h3>
+      <div style={{background: "#222"}}>
+          <JSONTree data={data} scrollToPath={hugeArrayKeyPath}/>
+      </div>
+      <br/>
 
-    <h3>Hide root node</h3>
-    <div style={{ background: "#222" }}>
-      <JSONTree hideRoot={true} data={data} />
-    </div>
-    <br />
+      <h3>Hide root node</h3>
+      <div style={{background: "#222"}}>
+          <JSONTree hideRoot={true} data={data}/>
+      </div>
+      <br/>
 
-    <h3>Force root node open</h3>
-    <div style={{ background: "#222" }}>
-      <JSONTree hideRootExpand={true} data={data} />
-    </div>
-    <br />
+      <h3>Force root node open</h3>
+      <div style={{background: "#222"}}>
+          <JSONTree hideRootExpand={true} data={data}/>
+      </div>
+      <br/>
 
-    <h3>No quotations around string values</h3>
-    <div style={{ background: "#222" }}>
-      <JSONTree valueWrap={""} data={data} />
-    </div>
-    <br />
+      <h3>No quotations around string values</h3>
+      <div style={{background: "#222"}}>
+          <JSONTree valueWrap={""} data={data}/>
+      </div>
+      <br/>
 
-    <h3>Theming Example</h3>
-    <p>
-      Styles are managed with css variables, override the default values to
-      customize.
-    </p>
-    <div
-      style={
-        {
-          "--json-tree-label-color": "rgb(12, 127, 149)",
-          "--json-tree-key-label-color": "rgb(71, 131, 0)",
-          "--json-tree-label-value-color": "rgb(255, 48, 124)",
-          "--json-tree-arrow-color": "rgb(12, 127, 149)",
-          "--json-tree-value-text-wrap": "nowrap",
-        } as React.CSSProperties
-      }
-    >
-      <JSONTree data={data} />
-    </div>
+      <h3>Theming Example</h3>
+      <p>
+          Styles are managed with css variables, override the default values to
+          customize.
+      </p>
+      <div
+          style={
+              {
+                  "--json-tree-label-color": "rgb(12, 127, 149)",
+                  "--json-tree-key-label-color": "rgb(71, 131, 0)",
+                  "--json-tree-label-value-color": "rgb(255, 48, 124)",
+                  "--json-tree-arrow-color": "rgb(12, 127, 149)",
+                  "--json-tree-value-text-wrap": "nowrap",
+              } as React.CSSProperties
+          }
+      >
+          <JSONTree data={data}/>
+      </div>
 
-    <h3>Theming Example - relative position arrows</h3>
-    <p>
-      Styles are managed with css variables, override the default values to
-      customize.
-    </p>
-    <div
-      style={
-        {
-          "--json-tree-label-color": "rgb(12, 127, 149)",
-          "--json-tree-key-label-color": "rgb(71, 131, 0)",
-          "--json-tree-label-value-color": "rgb(255, 48, 124)",
-          "--json-tree-arrow-color": "rgb(12, 127, 149)",
-          "--json-tree-arrow-position": "relative",
-          "--json-tree-ul-root-padding": "0",
-          "--json-tree-arrow-left-offset": "0",
-          "--json-tree-arrow-right-margin": "0.5em",
-        } as React.CSSProperties
-      }
-    >
-      <JSONTree data={data} />
-    </div>
+      <h3>Theming Example - relative position arrows</h3>
+      <p>
+          Styles are managed with css variables, override the default values to
+          customize.
+      </p>
+      <div
+          style={
+              {
+                  "--json-tree-label-color": "rgb(12, 127, 149)",
+                  "--json-tree-key-label-color": "rgb(71, 131, 0)",
+                  "--json-tree-label-value-color": "rgb(255, 48, 124)",
+                  "--json-tree-arrow-color": "rgb(12, 127, 149)",
+                  "--json-tree-arrow-position": "relative",
+                  "--json-tree-ul-root-padding": "0",
+                  "--json-tree-arrow-left-offset": "0",
+                  "--json-tree-arrow-right-margin": "0.5em",
+              } as React.CSSProperties
+          }
+      >
+          <JSONTree data={data}/>
+      </div>
 
-    <h3>Style Customization</h3>
-    <ul>
-      <li>
-        Label changes between uppercase/lowercase based on the expanded state.
-      </li>
-      <li>Array keys are styled based on their parity.</li>
-      <li>
-        The labels of objects, arrays, and iterables are customized as &quot;//
-        type&quot;.
-      </li>
-      <li>See code for details.</li>
-    </ul>
-    <div>
-      <JSONTree data={data} getItemString={getItemString} />
-    </div>
-    <h3>More Fine Grained Rendering</h3>
-    <p>
-      Pass <code>labelRenderer</code> or <code>valueRenderer</code>.
-    </p>
-    <div>
-      <JSONTree
-        data={data}
-        labelRenderer={([raw]) => <span>(({raw})):</span>}
-        valueRenderer={(raw) => (
-          <em>
+      <h3>Style Customization</h3>
+      <ul>
+          <li>
+              Label changes between uppercase/lowercase based on the expanded state.
+          </li>
+          <li>Array keys are styled based on their parity.</li>
+          <li>
+              The labels of objects, arrays, and iterables are customized as &quot;//
+              type&quot;.
+          </li>
+          <li>See code for details.</li>
+      </ul>
+      <div>
+          <JSONTree data={data} getItemString={getItemString}/>
+      </div>
+      <h3>More Fine Grained Rendering</h3>
+      <p>
+          Pass <code>labelRenderer</code> or <code>valueRenderer</code>.
+      </p>
+      <div>
+          <JSONTree
+              data={data}
+              labelRenderer={([raw]) => <span>(({raw})):</span>}
+              valueRenderer={(raw) => (
+                  <em>
             <span role="img" aria-label="mellow">
               😐
             </span>{" "}
-            {raw as string}{" "}
-            <span role="img" aria-label="mellow">
+                      {raw as string}{" "}
+                      <span role="img" aria-label="mellow">
               😐
             </span>
-          </em>
-        )}
-      />
-    </div>
-    <p>
-      Sort object keys with <code>sortObjectKeys</code> prop.
-    </p>
-    <div>
-      <JSONTree data={data} sortObjectKeys />
-    </div>
-    <p>Collapsed root node</p>
-    <div>
-      <JSONTree data={data} shouldExpandNodeInitially={() => false} />
-    </div>
+                  </em>
+              )}
+          />
+      </div>
+      <p>
+          Sort object keys with <code>sortObjectKeys</code> prop.
+      </p>
+      <div>
+          <JSONTree data={data} sortObjectKeys/>
+      </div>
+      <p>Collapsed root node</p>
+      <div>
+          <JSONTree data={data} shouldExpandNodeInitially={() => false}/>
+      </div>
 
-    <p>Collapsed top-level nodes</p>
-    <div>
-      <JSONTree
-        collectionLimit={100}
-        data={Array.from({ length: 10000 }).map((_, i) => ({
-          name: `item #${i}`,
-          value: i,
-        }))}
-      />
-    </div>
+      <p>Collapsed top-level nodes</p>
+      <div>
+          <JSONTree
+              collectionLimit={100}
+              data={Array.from({length: 10000}).map((_, i) => ({
+                  name: `item #${i}`,
+                  value: i,
+              }))}
+          />
+      </div>
+
+      <h3>Shift + click to toggle visualizing all child nodes</h3>
+      <div style={{background: "#222"}}>
+          <OnExpandExample />
+      </div>
+      <br/>
+
   </div>
 );
+
+function OnExpandExample() {
+    const [keyPathsToExpand, setKeyPathsToExpand] = React.useState<KeyPath[]>([])
+    return <div>
+        <div style={{color: 'white'}}>
+            KeyPaths that will be expanded: {JSON.stringify(keyPathsToExpand)}
+        </div>
+
+        <JSONTree
+            shouldExpandNodeInitially={(keyPath, data, level) => {
+                for(let i = 0; i < keyPathsToExpand.length; i++) {
+                    if(doesNodeContainNode(keyPathsToExpand[i], keyPath)) {
+                        return true;
+                    }
+                }
+
+                return level < 1
+            }}
+            data={data}
+            onExpand={(e, keyPath, expanded) => {
+            if ((e.ctrlKey || e.shiftKey || e.altKey)) {
+                if(expanded){
+                    setKeyPathsToExpand([...keyPathsToExpand.filter(existingKeyPath => !areKeyPathsEqual(existingKeyPath, keyPath)), keyPath])
+                }else {
+                    if(keyPathsToExpand.length) {
+                        setKeyPathsToExpand(keyPathsToExpand.filter(k => !areKeyPathsEqual(k, keyPath)))
+                    }
+                }
+
+            }
+        }}/>
+    </div>;
+}
+
 
 export default App;

--- a/src/ItemRange.tsx
+++ b/src/ItemRange.tsx
@@ -3,7 +3,8 @@ import JSONArrow from "./JSONArrow.js";
 import {
   CircularCache,
   CommonInternalProps,
-  KeyPath, OnExpandEvent,
+  KeyPath,
+  OnExpandEvent,
   ScrollToPath,
 } from "./types.js";
 import styles from "./styles/itemRange.module.scss";
@@ -21,7 +22,15 @@ interface Props extends CommonInternalProps {
 }
 
 export default function ItemRange(props: Props) {
-  const { from, to, renderChildNodes, nodeType, scrollToPath, keyPath, onExpand } = props;
+  const {
+    from,
+    to,
+    renderChildNodes,
+    nodeType,
+    scrollToPath,
+    keyPath,
+    onExpand,
+  } = props;
   let initialExpanded = false;
   if (scrollToPath) {
     const [index] = scrollToPath;
@@ -35,14 +44,16 @@ export default function ItemRange(props: Props) {
   }
 
   const [expanded, setExpanded] = useState<boolean>(initialExpanded);
-  const handleClick = useCallback((e: OnExpandEvent) => {
-    setExpanded(!expanded);
+  const handleClick = useCallback(
+    (e: OnExpandEvent) => {
+      setExpanded(!expanded);
 
-    if(onExpand !== undefined) {
-      onExpand(e, keyPath, expanded)
-    }
-
-  }, [expanded]);
+      if (onExpand !== undefined) {
+        onExpand(e, keyPath, expanded);
+      }
+    },
+    [expanded],
+  );
 
   return expanded ? (
     <div className={`${styles.itemRange}`}>

--- a/src/ItemRange.tsx
+++ b/src/ItemRange.tsx
@@ -3,7 +3,7 @@ import JSONArrow from "./JSONArrow.js";
 import {
   CircularCache,
   CommonInternalProps,
-  KeyPath,
+  KeyPath, OnExpandEvent,
   ScrollToPath,
 } from "./types.js";
 import styles from "./styles/itemRange.module.scss";
@@ -21,7 +21,7 @@ interface Props extends CommonInternalProps {
 }
 
 export default function ItemRange(props: Props) {
-  const { from, to, renderChildNodes, nodeType, scrollToPath, keyPath } = props;
+  const { from, to, renderChildNodes, nodeType, scrollToPath, keyPath, onExpand } = props;
   let initialExpanded = false;
   if (scrollToPath) {
     const [index] = scrollToPath;
@@ -35,8 +35,13 @@ export default function ItemRange(props: Props) {
   }
 
   const [expanded, setExpanded] = useState<boolean>(initialExpanded);
-  const handleClick = useCallback(() => {
+  const handleClick = useCallback((e: OnExpandEvent) => {
     setExpanded(!expanded);
+
+    if(onExpand !== undefined) {
+      onExpand(e, keyPath, expanded)
+    }
+
   }, [expanded]);
 
   return expanded ? (
@@ -48,7 +53,7 @@ export default function ItemRange(props: Props) {
       <JSONArrow
         nodeType={nodeType}
         expanded={false}
-        onClick={handleClick}
+        onNodeExpand={handleClick}
         arrowStyle="double"
       />
       {`${from} ... ${to}`}

--- a/src/JSONArrow.tsx
+++ b/src/JSONArrow.tsx
@@ -1,6 +1,6 @@
 import React, { EventHandler } from "react";
 import styles from "./styles/JSONArrow.module.scss";
-import {OnExpandEvent} from "./types.ts";
+import { OnExpandEvent } from "./types.ts";
 
 interface Props {
   arrowStyle?: "single" | "double";

--- a/src/JSONArrow.tsx
+++ b/src/JSONArrow.tsx
@@ -1,31 +1,32 @@
 import React, { EventHandler } from "react";
 import styles from "./styles/JSONArrow.module.scss";
+import {OnExpandEvent} from "./types.ts";
 
 interface Props {
   arrowStyle?: "single" | "double";
   expanded: boolean;
   nodeType: string;
-  onClick: () => void;
+  onNodeExpand: (e: OnExpandEvent) => void;
 }
 
 export default function JSONArrow({
   arrowStyle = "single",
   expanded,
-  onClick,
+  onNodeExpand,
 }: Props) {
   return (
     <div
       role={"button"}
       aria-expanded={expanded}
       tabIndex={0}
-      onClick={onClick}
+      onClick={onNodeExpand}
       onKeyDown={(event) => {
         if (event.key === "Enter" || event.key === " ") {
           event.preventDefault();
-          onClick();
+          onNodeExpand(event);
         }
       }}
-      className={`${styles.arrow} ${expanded ? styles.arrowExpanded : ""} ${arrowStyle === "single" ? styles.arrowArrowStyleSingle : styles.arrowArrowStyleDouble}`}
+      className={`${styles.arrow} ${expanded ? styles.arrowExpanded : ""}`}
     >
       {/* @todo let implementer define custom arrow object */}
       {"\u25B6"}

--- a/src/JSONNestedNode.tsx
+++ b/src/JSONNestedNode.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useState } from "react";
+import React, {useCallback, useEffect, useState} from "react";
 import JSONArrow from "./JSONArrow.js";
 import getCollectionEntries from "./getCollectionEntries.js";
 import JSONNode from "./JSONNode.js";
 import ItemRange from "./ItemRange.js";
-import type { CircularCache, CommonInternalProps } from "./types.js";
+import {CircularCache, CommonInternalProps, KeyPath, OnExpandEvent, ShouldExpandNode} from "./types.js";
 import styles from "./styles/JSONNestedNode.module.scss";
 import { NodeListItem } from "./components/NodeListItem.tsx";
 
@@ -116,6 +116,7 @@ export default function JSONNestedNode(props: Props) {
     nodeTypeIndicator,
     shouldExpandNodeInitially,
     scrollToPath,
+    onExpand
   } = props;
 
   const isRoot = keyPath[0] === "root";
@@ -129,8 +130,13 @@ export default function JSONNestedNode(props: Props) {
     isCircular ? false : shouldExpandNodeInitially(keyPath, data, level),
   );
 
-  const handleClick = useCallback(() => {
-    if (isNodeExpandable) setExpanded(!expanded);
+  const onNodeExpand = useCallback((e: OnExpandEvent) => {
+    if (isNodeExpandable) {
+      if(onExpand){
+        onExpand(e, keyPath, !expanded)
+      }
+      setExpanded(!expanded);
+    }
   }, [isNodeExpandable, expanded]);
 
   const renderedChildren =
@@ -179,18 +185,18 @@ export default function JSONNestedNode(props: Props) {
           <JSONArrow
             nodeType={nodeType}
             expanded={expanded}
-            onClick={handleClick}
+            onNodeExpand={onNodeExpand}
           />
         )}
         <span
           data-nodetype={nodeType}
           data-keypath={keyPath[0]}
           className={`${styles.nestedNodeLabel} ${expanded ? styles.nestedNodeLabelExpanded : ""} ${isNodeExpandable ? styles.nestedNodeLabelExpandable : ""}`}
-          onClick={handleClick}
+          onClick={onNodeExpand}
         >
           {labelRenderer(...stylingArgs)}
         </span>
-        <span className={styles.nestedNodeItemString} onClick={handleClick}>
+        <span className={styles.nestedNodeItemString} onClick={onNodeExpand}>
           {renderedItemString}
         </span>
       </span>

--- a/src/JSONNestedNode.tsx
+++ b/src/JSONNestedNode.tsx
@@ -1,9 +1,15 @@
-import React, {useCallback, useEffect, useState} from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import JSONArrow from "./JSONArrow.js";
 import getCollectionEntries from "./getCollectionEntries.js";
 import JSONNode from "./JSONNode.js";
 import ItemRange from "./ItemRange.js";
-import {CircularCache, CommonInternalProps, KeyPath, OnExpandEvent, ShouldExpandNode} from "./types.js";
+import {
+  CircularCache,
+  CommonInternalProps,
+  KeyPath,
+  OnExpandEvent,
+  ShouldExpandNode,
+} from "./types.js";
 import styles from "./styles/JSONNestedNode.module.scss";
 import { NodeListItem } from "./components/NodeListItem.tsx";
 
@@ -116,7 +122,7 @@ export default function JSONNestedNode(props: Props) {
     nodeTypeIndicator,
     shouldExpandNodeInitially,
     scrollToPath,
-    onExpand
+    onExpand,
   } = props;
 
   const isRoot = keyPath[0] === "root";
@@ -130,14 +136,17 @@ export default function JSONNestedNode(props: Props) {
     isCircular ? false : shouldExpandNodeInitially(keyPath, data, level),
   );
 
-  const onNodeExpand = useCallback((e: OnExpandEvent) => {
-    if (isNodeExpandable) {
-      if(onExpand){
-        onExpand(e, keyPath, !expanded)
+  const onNodeExpand = useCallback(
+    (e: OnExpandEvent) => {
+      if (isNodeExpandable) {
+        if (onExpand) {
+          onExpand(e, keyPath, !expanded);
+        }
+        setExpanded(!expanded);
       }
-      setExpanded(!expanded);
-    }
-  }, [isNodeExpandable, expanded]);
+    },
+    [isNodeExpandable, expanded],
+  );
 
   const renderedChildren =
     expanded || (hideRoot && level === 0)

--- a/src/JSONNode.tsx
+++ b/src/JSONNode.tsx
@@ -17,6 +17,7 @@ export default function JSONNode({
   valueRenderer,
   isCustomNode,
   valueWrap,
+
   scrollToPath,
   ...rest
 }: Props) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -57,6 +57,7 @@ export function JSONTree({
   sortObjectKeys = false,
   scrollToPath,
   valueWrap = '"',
+  onExpand = undefined,
 }: JSONTreeProps) {
   return (
     <ul
@@ -80,6 +81,8 @@ export function JSONTree({
         collectionLimit={collectionLimit}
         sortObjectKeys={sortObjectKeys}
         valueWrap={valueWrap}
+        onExpand={onExpand}
+
       />
     </ul>
   );
@@ -97,6 +100,19 @@ export const areKeyPathsEqual = (a: KeyPath, b: KeyPath) => {
   return true;
 };
 
+/**
+ * Returns true if source is a child node of target
+ * Remember child nodes have a longer key path
+ */
+export const doesNodeContainNode = (parent: KeyPath, child: KeyPath): boolean => {
+  for (let i = parent.length - 1; i >= 0; i--) {
+    if (parent[parent.length - i] !== child[child.length - i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export type {
   Key,
   KeyPath,
@@ -108,4 +124,5 @@ export type {
   IsCustomNode,
   SortObjectKeys,
   CommonExternalProps,
+  ScrollToPath
 } from "./types.js";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -82,7 +82,6 @@ export function JSONTree({
         sortObjectKeys={sortObjectKeys}
         valueWrap={valueWrap}
         onExpand={onExpand}
-
       />
     </ul>
   );
@@ -104,14 +103,17 @@ export const areKeyPathsEqual = (a: KeyPath, b: KeyPath) => {
  * Returns true if source is a child node of target
  * Remember child nodes have a longer key path
  */
-export const doesNodeContainNode = (parent: KeyPath, child: KeyPath): boolean => {
+export const doesNodeContainNode = (
+  parent: KeyPath,
+  child: KeyPath,
+): boolean => {
   for (let i = parent.length - 1; i >= 0; i--) {
     if (parent[parent.length - i] !== child[child.length - i]) {
       return false;
     }
   }
   return true;
-}
+};
 
 export type {
   Key,
@@ -124,5 +126,5 @@ export type {
   IsCustomNode,
   SortObjectKeys,
   CommonExternalProps,
-  ScrollToPath
+  ScrollToPath,
 } from "./types.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,13 @@ export type ShouldExpandNodeInitially = (
   level: number,
 ) => boolean;
 
+export type ShouldExpandNode = (
+    keyPath: KeyPath,
+    data: unknown,
+    level: number,
+) => boolean | undefined;
+
+
 export type PostprocessValue = (value: unknown) => unknown;
 
 export type IsCustomNode = (value: unknown) => boolean;
@@ -48,10 +55,13 @@ export type SortObjectKeys = ((a: unknown, b: unknown) => number) | boolean;
 
 export type CircularCache = unknown[];
 
+export type OnExpandEvent = React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement> | React.MouseEvent<HTMLSpanElement>
+
 export interface CommonExternalProps {
   keyPath: KeyPath;
   labelRenderer: LabelRenderer;
   valueRenderer: ValueRenderer;
+  // Sets expanded state on initial render, will not update expanded state on subsequent renders to prevent changing nodes user has interacted with already
   shouldExpandNodeInitially: ShouldExpandNodeInitially;
   hideRoot: boolean;
   hideRootExpand: boolean;
@@ -62,6 +72,7 @@ export interface CommonExternalProps {
   sortObjectKeys: SortObjectKeys;
   valueWrap: string;
   scrollToPath?: ScrollToPath;
+  onExpand?: (event: OnExpandEvent, keyPath: KeyPath, expand: boolean) => void
 }
 
 export interface CommonInternalProps extends CommonExternalProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,11 +41,10 @@ export type ShouldExpandNodeInitially = (
 ) => boolean;
 
 export type ShouldExpandNode = (
-    keyPath: KeyPath,
-    data: unknown,
-    level: number,
+  keyPath: KeyPath,
+  data: unknown,
+  level: number,
 ) => boolean | undefined;
-
 
 export type PostprocessValue = (value: unknown) => unknown;
 
@@ -55,7 +54,10 @@ export type SortObjectKeys = ((a: unknown, b: unknown) => number) | boolean;
 
 export type CircularCache = unknown[];
 
-export type OnExpandEvent = React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement> | React.MouseEvent<HTMLSpanElement>
+export type OnExpandEvent =
+  | React.MouseEvent<HTMLDivElement>
+  | React.KeyboardEvent<HTMLDivElement>
+  | React.MouseEvent<HTMLSpanElement>;
 
 export interface CommonExternalProps {
   keyPath: KeyPath;
@@ -72,7 +74,7 @@ export interface CommonExternalProps {
   sortObjectKeys: SortObjectKeys;
   valueWrap: string;
   scrollToPath?: ScrollToPath;
-  onExpand?: (event: OnExpandEvent, keyPath: KeyPath, expand: boolean) => void
+  onExpand?: (event: OnExpandEvent, keyPath: KeyPath, expand: boolean) => void;
 }
 
 export interface CommonInternalProps extends CommonExternalProps {


### PR DESCRIPTION
Provide optional onExpand callback to give more flexibility in overriding default behavior.

For example, allowing users to visualize all child nodes on shift + click.
https://github.com/user-attachments/assets/fafe3389-9785-4c2d-a732-8c27cc1b006f

